### PR TITLE
Write to a Stream rather than a File, avoid left over temp files

### DIFF
--- a/lib/simple_xlsx/document.rb
+++ b/lib/simple_xlsx/document.rb
@@ -8,9 +8,8 @@ module SimpleXlsx
     attr_reader :sheets
 
     def add_sheet name, &block
-      @io.open_stream_for_sheet(@sheets.size) do |stream|
-        @sheets << Sheet.new(self, name, stream, &block)
-      end
+      stream = @io.open_stream_for_sheet(@sheets.size)
+      @sheets << Sheet.new(self, name, stream, &block)
     end
 
     def has_shared_strings?

--- a/lib/simple_xlsx/serializer.rb
+++ b/lib/simple_xlsx/serializer.rb
@@ -18,17 +18,16 @@ class Serializer
 
   def add_workbook_part
     @zip.put_next_entry("xl/workbook.xml")
-    f = @zip
-    f.puts <<-ends
+    @zip.puts <<-ends
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
 <workbookPr date1904="0" />
 <sheets>
 ends
     @doc.sheets.each_with_index do |sheet, ndx|
-      f.puts %Q{<sheet name="#{sheet.name}" sheetId="#{ndx + 1}" r:id="#{sheet.rid}"/>}
+      @zip.puts %Q{<sheet name="#{sheet.name}" sheetId="#{ndx + 1}" r:id="#{sheet.rid}"/>}
     end
-    f.puts "</sheets></workbook>"
+    @zip.puts "</sheets></workbook>"
   end
 
   def open_stream_for_sheet ndx
@@ -38,10 +37,9 @@ ends
 
   def add_content_types
     @zip.put_next_entry("[Content_Types].xml")
-    f = @zip
-    f.puts '<?xml version="1.0" encoding="UTF-8"?>'
-    f.puts '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
-    f.puts <<-ends
+    @zip.puts '<?xml version="1.0" encoding="UTF-8"?>'
+    @zip.puts '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
+    @zip.puts <<-ends
   <Override PartName="/_rels/.rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
   <Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>
   <Override PartName="/docProps/app.xml" ContentType="application/vnd.openxmlformats-officedocument.extended-properties+xml"/>
@@ -49,51 +47,48 @@ ends
   <Override PartName="/xl/_rels/workbook.xml.rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
 ends
     if @doc.has_shared_strings?
-      f.puts '<Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>'
+      @zip.puts '<Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>'
     end
     @doc.sheets.each_with_index do |sheet, ndx|
-      f.puts %Q{<Override PartName="/xl/worksheets/sheet#{ndx+1}.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>}
+      @zip.puts %Q{<Override PartName="/xl/worksheets/sheet#{ndx+1}.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>}
     end
-    f.puts '<Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>'
-    f.puts "</Types>"
+    @zip.puts '<Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>'
+    @zip.puts "</Types>"
   end
 
   def add_workbook_relationship_part
     @zip.put_next_entry("xl/_rels/workbook.xml.rels")
-    f = @zip
-    f.puts <<-ends
+    @zip.puts <<-ends
 <?xml version="1.0" encoding="UTF-8"?>
 <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
 ends
     cnt = 0
-    f.puts %Q{<Relationship Id="rId#{cnt += 1}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>}
+    @zip.puts %Q{<Relationship Id="rId#{cnt += 1}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>}
     @doc.sheets.each_with_index do |sheet, ndx|
       sheet.rid = "rId#{cnt += 1}"
-      f.puts %Q{<Relationship Id="#{sheet.rid}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet#{ndx + 1}.xml"/>}
+      @zip.puts %Q{<Relationship Id="#{sheet.rid}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet#{ndx + 1}.xml"/>}
     end
     if @doc.has_shared_strings?
-      f.puts '<Relationship Id="rId#{cnt += 1}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="xl/sharedStrings.xml"/>'
+      @zip.puts '<Relationship Id="rId#{cnt += 1}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="xl/sharedStrings.xml"/>'
     end
-    f.puts "</Relationships>"
+    @zip.puts "</Relationships>"
   end
 
   def add_relationship_part
     @zip.put_next_entry("_rels/.rels")
-    f = @zip
-    f.puts <<-ends
+    @zip.puts <<-ends
 <?xml version="1.0" encoding="UTF-8"?>
 <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
   <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
   <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>
   <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties" Target="docProps/app.xml"/>
 ends
-    f.puts "</Relationships>"
+    @zip.puts "</Relationships>"
   end
 
   def add_doc_props
     @zip.put_next_entry("docProps/core.xml")
-    f = @zip
-    f.puts <<-ends
+    @zip.puts <<-ends
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcmitype="http://purl.org/dc/dcmitype/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <dcterms:created xsi:type="dcterms:W3CDTF">#{Time.now.utc.xmlschema}</dcterms:created>
@@ -101,8 +96,7 @@ ends
 </cp:coreProperties>
 ends
     @zip.put_next_entry("docProps/app.xml")
-    f = @zip
-    f.puts <<-ends
+    @zip.puts <<-ends
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties" xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">
   <TotalTime>0</TotalTime>
@@ -112,8 +106,7 @@ ends
 
   def add_styles
     @zip.put_next_entry("xl/styles.xml")
-    f = @zip
-    f.puts <<-ends
+    @zip.puts <<-ends
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
 <numFmts count="7">

--- a/lib/simple_xlsx/serializer.rb
+++ b/lib/simple_xlsx/serializer.rb
@@ -2,7 +2,9 @@ module SimpleXlsx
 
 class Serializer
 
-  def initialize tempfile
+  def initialize file_path
+    tempfile = Tempfile.new(File.basename(file_path))
+
     Zip::ZipOutputStream.open(tempfile.path) do |zip|
       @zip = zip
       add_doc_props
@@ -14,6 +16,9 @@ class Serializer
       add_content_types
       add_workbook_part
     end
+
+    FileUtils.mkdir_p(File.dirname(file_path))
+    FileUtils.cp(tempfile.path, file_path)
   end
 
   def add_workbook_part

--- a/lib/simple_xlsx/serializer.rb
+++ b/lib/simple_xlsx/serializer.rb
@@ -26,7 +26,7 @@ class Serializer
 <sheets>
 ends
     @doc.sheets.each_with_index do |sheet, ndx|
-      f.puts "<sheet name=\"#{sheet.name}\" sheetId=\"#{ndx + 1}\" r:id=\"#{sheet.rid}\"/>"
+      f.puts %Q{<sheet name="#{sheet.name}" sheetId="#{ndx + 1}" r:id="#{sheet.rid}"/>}
     end
     f.puts "</sheets></workbook>"
   end
@@ -52,7 +52,7 @@ ends
       f.puts '<Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>'
     end
     @doc.sheets.each_with_index do |sheet, ndx|
-      f.puts "<Override PartName=\"/xl/worksheets/sheet#{ndx+1}.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\"/>"
+      f.puts %Q{<Override PartName="/xl/worksheets/sheet#{ndx+1}.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>}
     end
     f.puts '<Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>'
     f.puts "</Types>"
@@ -66,10 +66,10 @@ ends
 <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
 ends
     cnt = 0
-    f.puts "<Relationship Id=\"rId#{cnt += 1}\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles\" Target=\"styles.xml\"/>"
+    f.puts %Q{<Relationship Id="rId#{cnt += 1}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>}
     @doc.sheets.each_with_index do |sheet, ndx|
       sheet.rid = "rId#{cnt += 1}"
-      f.puts "<Relationship Id=\"#{sheet.rid}\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\" Target=\"worksheets/sheet#{ndx + 1}.xml\"/>"
+      f.puts %Q{<Relationship Id="#{sheet.rid}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet#{ndx + 1}.xml"/>}
     end
     if @doc.has_shared_strings?
       f.puts '<Relationship Id="rId#{cnt += 1}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="xl/sharedStrings.xml"/>'

--- a/lib/simple_xlsx/sheet.rb
+++ b/lib/simple_xlsx/sheet.rb
@@ -24,10 +24,10 @@ ends
   end
 
   def add_row arry
-    row = ["<row r=\"#{@row_ndx}\">"]
+    row = [%Q{<row r="#{@row_ndx}">}]
     arry.each_with_index do |value, col_ndx|
       kind, ccontent, cstyle = Sheet.format_field_and_type_and_style value
-      row << "<c r=\"#{Sheet.column_index(col_ndx)}#{@row_ndx}\" t=\"#{kind.to_s}\" s=\"#{cstyle}\">#{ccontent}</c>"
+      row << %Q{<c r="#{Sheet.column_index(col_ndx)}#{@row_ndx}" t="#{kind.to_s}" s="#{cstyle}">#{ccontent}</c>}
     end
     row << "</row>"
     @row_ndx += 1

--- a/test/simple_xlsx/document_test.rb
+++ b/test/simple_xlsx/document_test.rb
@@ -6,7 +6,7 @@ class DocumentTest < Test::Unit::TestCase
 
   def open_stream_for_sheet sheets_size
     assert_equal sheets_size, @doc.sheets.size
-    yield self
+    self
   end
 
   def write arg

--- a/test/simple_xlsx/sheet_test.rb
+++ b/test/simple_xlsx/sheet_test.rb
@@ -72,7 +72,7 @@ class SheetTest < Test::Unit::TestCase
     assert row
     assert_equal '1', row.attributes['r']
     assert_equal 2, row.elements.to_a.size
-    assert_equal ["r", "s", "t"], row.elements.to_a[0].attributes.keys
+    assert_equal %w[r s t], row.elements.to_a[0].attributes.keys.sort
   end
 
 

--- a/test/simple_xlsx_test.rb
+++ b/test/simple_xlsx_test.rb
@@ -3,9 +3,16 @@ require 'fileutils'
 
 class SimpleXlsxTest < Test::Unit::TestCase
 
-  def test_top_level
+  def setup
     FileUtils.rm_f "test.xlsx"
-    o = SimpleXlsx::Serializer.new(Tempfile.new("test.xlsx")) do |doc|
+  end
+
+  def teardown
+    FileUtils.rm_f "test.xlsx"
+  end
+
+  def test_top_level
+    o = SimpleXlsx::Serializer.new("test.xlsx") do |doc|
       doc.add_sheet "First" do |sheet|
         sheet.add_row ["Hello", "World", 3.14, 7]
         sheet.add_row ["Another", "Row", Date.today, Time.parse('2010-Jul-24 12:00 UTC')]

--- a/test/simple_xlsx_test.rb
+++ b/test/simple_xlsx_test.rb
@@ -5,7 +5,7 @@ class SimpleXlsxTest < Test::Unit::TestCase
 
   def test_top_level
     FileUtils.rm_f "test.xlsx"
-    o = SimpleXlsx::Serializer.new("test.xlsx") do |doc|
+    o = SimpleXlsx::Serializer.new(Tempfile.new("test.xlsx")) do |doc|
       doc.add_sheet "First" do |sheet|
         sheet.add_row ["Hello", "World", 3.14, 7]
         sheet.add_row ["Another", "Row", Date.today, Time.parse('2010-Jul-24 12:00 UTC')]


### PR DESCRIPTION
I have cherry-picked from two of @justincbeck’s commits 
(https://github.com/justincbeck/simple_xlsx_writer/compare/1cd6b4ba...36c72963) and added a bit to make the tests pass again. Now, when generating the XLSX file, there is no longer any left over temp files in the export folder.

I see (just now) that you have discussed this (“the Jussi Pasenan patch”) in https://github.com/harvesthq/simple_xlsx_writer/issues/2. In the last commit of this pull request, I have changed the implementation so that you pass a String (export path) to `Serializer.new`, which in turn creates the Tempfile and finally copies the generated file into the mentioned export path.